### PR TITLE
YOLOv9-QAT 

### DIFF
--- a/models/quantize.py
+++ b/models/quantize.py
@@ -1,0 +1,479 @@
+################################################################################
+# SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+################################################################################
+
+
+import os
+import re
+from typing import List, Callable, Union, Dict
+from tqdm import tqdm
+from copy import deepcopy
+
+# PyTorch
+import torch
+import torch.optim as optim
+from torch.cuda import amp
+
+from utils.loss_tal import ComputeLoss
+
+# Pytorch Quantization
+from pytorch_quantization import nn as quant_nn
+from pytorch_quantization.nn.modules import _utils as quant_nn_utils
+from pytorch_quantization import calib
+from pytorch_quantization.tensor_quant import QuantDescriptor
+from pytorch_quantization import quant_modules
+from pytorch_quantization import tensor_quant
+from absl import logging as quant_logging
+
+import torch.nn.functional as F
+
+from utils.general import (LOGGER,colorstr,check_amp)
+                           
+# Custom Rules
+from models.quantize_rules import find_quantizer_pairs
+import models
+
+
+### These classes has not been utilized yet; it's still undergoing testing. #####
+### BEGIN #####
+class QuantSiLU(torch.nn.Module, quant_nn_utils.QuantInputMixin):
+    def __init__(self, **kwargs):
+        super(QuantSiLU, self).__init__()
+        self._input0_quantizer = quant_nn.TensorQuantizer(QuantDescriptor(num_bits=8, calib_method="histogram"))
+        self._input1_quantizer = quant_nn.TensorQuantizer(QuantDescriptor(num_bits=8, calib_method="histogram"))
+        self._input0_quantizer._calibrator._torch_hist = True
+        self._input1_quantizer._calibrator._torch_hist = True
+        
+    def forward(self, input):
+        return self._input0_quantizer(input) * self._input1_quantizer(torch.sigmoid(input))
+    
+class QuantRepNCSPELAN4Chunk(torch.nn.Module):
+        def __init__(self, c):
+            super().__init__()
+            self._input0_quantizer = quant_nn.TensorQuantizer(QuantDescriptor())
+            self.c = c
+        def forward(self, x, chunks, dims):
+            return torch.split(self._input0_quantizer(x), (self.c, self.c), dims)
+
+class QuantUpsample(torch.nn.Module): 
+        def __init__(self, size, scale_factor, mode):
+            super().__init__()
+            self.size = size
+            self.scale_factor = scale_factor
+            self.mode = mode
+            self._input_quantizer = quant_nn.TensorQuantizer(QuantDescriptor())
+            
+        def forward(self, x):
+            return F.interpolate(self._input_quantizer(x), self.size, self.scale_factor, self.mode)
+           
+### END #####
+        
+class QuantConcat(torch.nn.Module, quant_nn_utils.QuantInputMixin):
+    def __init__(self, dimension=1):
+        super(QuantConcat, self).__init__()
+        self._input_quantizer = quant_nn.TensorQuantizer(QuantDescriptor(num_bits=8, calib_method="histogram"))
+        self._input_quantizer._calibrator._torch_hist = True
+        self.dimension = dimension         
+  
+    def forward(self, inputs):
+        inputs = [self._input_quantizer(input) for input in inputs]
+        return torch.cat(inputs, self.dimension)
+              
+class QuantAdd(torch.nn.Module, quant_nn_utils.QuantMixin):
+    def __init__(self, quantization):
+        super().__init__()
+        
+        if quantization:
+            self._input0_quantizer = quant_nn.TensorQuantizer(QuantDescriptor())
+            self._input1_quantizer = quant_nn.TensorQuantizer(QuantDescriptor())
+        self.quantization = quantization
+
+    def forward(self, x, y):
+        if self.quantization:
+            #rint(f"QAdd {self._input0_quantizer}  {self._input1_quantizer}")
+            return self._input0_quantizer(x) + self._input1_quantizer(y)
+        return x + y
+                
+  
+
+class disable_quantization:
+    def __init__(self, model):
+        self.model  = model
+
+    def apply(self, disabled=True):
+        for name, module in self.model.named_modules():
+            if isinstance(module, quant_nn.TensorQuantizer):
+                module._disabled = disabled
+
+    def __enter__(self):
+        self.apply(True)
+
+    def __exit__(self, *args, **kwargs):
+        self.apply(False)
+
+
+class enable_quantization:
+    def __init__(self, model):
+        self.model  = model
+
+    def apply(self, enabled=True):
+        for name, module in self.model.named_modules():
+            if isinstance(module, quant_nn.TensorQuantizer):
+                module._disabled = not enabled
+
+    def __enter__(self):
+        self.apply(True)
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        self.apply(False)
+
+
+def have_quantizer(module):
+    for name, module in module.named_modules():
+        if isinstance(module, quant_nn.TensorQuantizer):
+            return True
+
+
+# Initialize PyTorch Quantization
+def initialize():
+    quant_modules.initialize( )
+    quant_desc_input = QuantDescriptor(calib_method="histogram")
+    quant_nn.QuantConv2d.set_default_quant_desc_input(quant_desc_input)
+    quant_nn.QuantMaxPool2d.set_default_quant_desc_input(quant_desc_input)
+    quant_nn.QuantAvgPool2d.set_default_quant_desc_input(quant_desc_input)
+    quant_nn.QuantLinear.set_default_quant_desc_input(quant_desc_input)
+
+    quant_logging.set_verbosity(quant_logging.ERROR)
+
+    quant_modules._DEFAULT_QUANT_MAP.extend(
+             [quant_modules._quant_entry(models.common, "Concat", QuantConcat)]
+         )
+ 
+
+
+def transfer_torch_to_quantization(nninstance : torch.nn.Module, quantmodule):
+    quant_instance = quantmodule.__new__(quantmodule)
+    for k, val in vars(nninstance).items():
+        setattr(quant_instance, k, val)
+
+    def __init__(self):
+        if self.__class__.__name__ == 'QuantConcat': 
+           self.__init__()
+        elif isinstance(self, quant_nn_utils.QuantInputMixin):
+            quant_desc_input, quant_desc_weight = quant_nn_utils.pop_quant_desc_in_kwargs(self.__class__)
+            self.init_quantizer(quant_desc_input)
+
+            # Turn on torch_hist to enable higher calibration speeds
+            if isinstance(self._input_quantizer._calibrator, calib.HistogramCalibrator):
+                self._input_quantizer._calibrator._torch_hist = True
+        else:
+            quant_desc_input, quant_desc_weight = quant_nn_utils.pop_quant_desc_in_kwargs(self.__class__)
+            self.init_quantizer(quant_desc_input, quant_desc_weight)
+            # Turn on torch_hist to enable higher calibration speeds
+            if isinstance(self._input_quantizer._calibrator, calib.HistogramCalibrator):
+                self._input_quantizer._calibrator._torch_hist = True
+                self._weight_quantizer._calibrator._torch_hist = True
+
+    __init__(quant_instance)
+    return quant_instance
+
+
+def quantization_ignore_match(ignore_policy : Union[str, List[str], Callable], path : str) -> bool:
+
+    if ignore_policy is None: return False
+    if isinstance(ignore_policy, Callable):
+        return ignore_policy(path)
+
+    if isinstance(ignore_policy, str) or isinstance(ignore_policy, List):
+
+        if isinstance(ignore_policy, str):
+            ignore_policy = [ignore_policy]
+
+        if path in ignore_policy: return True
+        for item in ignore_policy:
+            if re.match(item, path):
+                return True
+    return False
+
+ 
+def replace_to_quantization_module(model : torch.nn.Module, ignore_policy : Union[str, List[str], Callable] = None, prefixx=colorstr('QAT:')):
+
+    module_dict = {}
+    for entry in quant_modules._DEFAULT_QUANT_MAP:
+        module = getattr(entry.orig_mod, entry.mod_name)
+        module_dict[id(module)] = entry.replace_mod
+
+    def recursive_and_replace_module(module, prefix=""):
+        for name in module._modules:
+            submodule = module._modules[name]
+            path      = name if prefix == "" else prefix + "." + name
+            recursive_and_replace_module(submodule, path)
+
+            submodule_id = id(type(submodule))
+            if submodule_id in module_dict:
+                ignored = quantization_ignore_match(ignore_policy, path)
+                if ignored:
+                    LOGGER.info(f'{prefixx} Quantization: {path} has ignored.')
+                    continue
+                    
+                module._modules[name] = transfer_torch_to_quantization(submodule, module_dict[submodule_id])
+
+    recursive_and_replace_module(model)
+
+
+def get_attr_with_path(m, path):
+    def sub_attr(m, names):
+        name = names[0]
+        value = getattr(m, name)
+        if len(names) == 1:
+            return value
+        return sub_attr(value, names[1:])
+    return sub_attr(m, path.split("."))
+
+
+def repnbottleneck_quant_forward(self, x):
+    if hasattr(self, "repaddop"):
+        return self.repaddop(x, self.cv2(self.cv1(x))) if self.add else self.cv2(self.cv1(x))
+    return x + self.cv2(self.cv1(x)) if self.add else self.cv2(self.cv1(x))
+
+
+def concat_quant_forward(self, x):
+        if hasattr(self, "concatop"):
+            return self.concatop(x, self.d)
+        return torch.cat(x, self.d)
+
+### These def has not been utilized yet; it's still undergoing testing. #####
+### Begin #### 
+def upsample_quant_forward(self, x):
+        if hasattr(self, "upsampleop"):
+            return self.upsampleop(x)
+        return F.interpolate(x)
+
+def repncspelan4_qaunt_forward(self, x):
+        if hasattr(self, "repncspelan4chunkop"):
+            y = list(self.repncspelan4chunkop(self.cv1(x),2, 1))
+            y.extend(m(y[-1])  for m in [self.cv2, self.cv3])
+            return self.cv4(torch.cat(y, 1))
+        else:
+            y = list(self.cv1(x).split((self.c, self.c), 1))
+            y.extend(m(y[-1]) for m in [self.cv2, self.cv3])
+            return self.cv4(torch.cat(y, 1))
+        
+### End #### 
+
+def apply_custom_rules_to_quantizer(model : torch.nn.Module, export_onnx : Callable):
+
+    # apply rules to graph
+    export_onnx(model,  "quantization-custom-rules-temp.onnx")
+    pairs = find_quantizer_pairs("quantization-custom-rules-temp.onnx")
+    for major, sub in pairs:
+        print(f"Rules: {sub} match to {major}")
+        get_attr_with_path(model, sub)._input_quantizer = get_attr_with_path(model, major)._input_quantizer
+    os.remove("quantization-custom-rules-temp.onnx")
+
+    for name, module in model.named_modules():
+        if module.__class__.__name__ == "RepNBottleneck":
+            if module.add:
+                print(f"Rules: {name}.add match to {name}.cv1")
+                major = module.cv1.conv._input_quantizer
+                module.repaddop._input0_quantizer = major
+                module.repaddop._input1_quantizer = major
+
+def replace_custom_module_forward(model):
+    for name, module  in model.named_modules():
+            if module.__class__.__name__ == "RepNBottleneck":
+                if module.add:
+                    if not hasattr(module, "repaddop"):
+                        #print(f"Add QuantAdd to {name}")
+                        module.repaddop = QuantAdd(module.add)
+                    module.__class__.forward = repnbottleneck_quant_forward
+    
+
+def calibrate_model(model : torch.nn.Module, dataloader, device, num_batch=25):
+
+    def compute_amax(model, **kwargs):
+        for name, module in model.named_modules():
+            if isinstance(module, quant_nn.TensorQuantizer):
+                if module._calibrator is not None:
+                    if isinstance(module._calibrator, calib.MaxCalibrator):
+                        module.load_calib_amax()
+                    else:
+                        module.load_calib_amax(**kwargs)
+
+                    module._amax = module._amax.to(device)
+        
+    def collect_stats(model, data_loader, device, num_batch=200):
+        """Feed data to the network and collect statistics"""
+        # Enable calibrators
+        model.eval()
+        for name, module in model.named_modules():
+
+            if isinstance(module, quant_nn.TensorQuantizer):
+                if module._calibrator is not None:
+                    module.disable_quant()
+                    module.enable_calib()
+                else:
+                    module.disable()
+
+        # Feed data to the network for collecting stats
+        with torch.no_grad():
+            for i, datas in tqdm(enumerate(data_loader), total=num_batch, desc="Collect stats for calibrating"):
+                imgs = datas[0].to(device, non_blocking=True).float() / 255.0
+                model(imgs)
+
+                if i >= num_batch:
+                    break
+
+        # Disable calibrators
+        for name, module in model.named_modules():
+            if isinstance(module, quant_nn.TensorQuantizer):
+                if module._calibrator is not None:
+                    module.enable_quant()
+                    module.disable_calib()
+                else:
+                    module.enable()
+    
+    with torch.no_grad():
+        collect_stats(model, dataloader, device, num_batch=num_batch)
+        compute_amax(model, method="percentile", percentile=99.999, strict=False) # strict=False avoid Exception when some quantizer are never used
+   
+
+
+def finetune(
+    model : torch.nn.Module, train_dataloader, no_last_layer, per_epoch_callback : Callable = None, preprocess : Callable = None,
+    nepochs=10, early_exit_batchs_per_epoch=1000, lrschedule : Dict = None, fp16=True, learningrate=1e-5,
+    supervision_policy : Callable = None, prefix=colorstr('QAT:')
+):
+    origin_model = deepcopy(model).eval()
+    disable_quantization(origin_model).apply()
+                    
+    model.train()
+    model.requires_grad_(True)
+
+    scaler       = amp.GradScaler(enabled=fp16)
+    optimizer    = optim.Adam(model.parameters(), learningrate)
+    quant_lossfn = torch.nn.MSELoss()
+    device       = next(model.parameters()).device
+
+    if no_last_layer:
+        last_layer_index = len(model.model) - 1
+        last_layer = model.model[last_layer_index]
+        if have_quantizer(last_layer):
+            LOGGER.info(f'{prefix} Quantization disabled for Last Layer model.{last_layer_index}')
+            disable_quantization(last_layer).apply()
+
+    if lrschedule is None:
+        lrschedule = {
+            0: 1e-6,
+            3: 1e-5,
+            8: 1e-6
+        }
+
+
+    def make_layer_forward_hook(l):
+        def forward_hook(m, input, output):
+            l.append(output)
+        return forward_hook
+
+    supervision_module_pairs = []
+    for ((mname, ml), (oriname, ori)) in zip(model.named_modules(), origin_model.named_modules()):
+        if isinstance(ml, quant_nn.TensorQuantizer): continue
+
+        if supervision_policy:
+            if not supervision_policy(mname, ml):
+                continue
+
+        supervision_module_pairs.append([ml, ori])
+
+
+    for iepoch in range(nepochs):
+
+        if iepoch in lrschedule:
+            learningrate = lrschedule[iepoch]
+            for g in optimizer.param_groups:
+                g["lr"] = learningrate
+
+        model_outputs  = []
+        origin_outputs = []
+        remove_handle  = []
+        
+
+
+        for ml, ori in supervision_module_pairs:
+            remove_handle.append(ml.register_forward_hook(make_layer_forward_hook(model_outputs))) 
+            remove_handle.append(ori.register_forward_hook(make_layer_forward_hook(origin_outputs)))
+
+        model.train()
+        pbar = tqdm(train_dataloader, desc="QAT", total=early_exit_batchs_per_epoch)
+        for ibatch, imgs in enumerate(pbar):
+
+            if ibatch >= early_exit_batchs_per_epoch:
+                break
+            
+            if preprocess:
+                imgs = preprocess(imgs)
+                
+
+            imgs = imgs.to(device)
+            with amp.autocast(enabled=fp16):
+                model(imgs)
+
+                with torch.no_grad():
+                    origin_model(imgs)
+
+                quant_loss = 0
+                for mo, fo in zip(model_outputs, origin_outputs):
+                    for m, f in zip(mo, fo):
+                        quant_loss += quant_lossfn(m, f)
+
+                model_outputs.clear()
+                origin_outputs.clear()
+
+            if fp16:
+                scaler.scale(quant_loss).backward()
+                scaler.step(optimizer)
+                scaler.update()
+            else:
+                quant_loss.backward()
+                optimizer.step()
+            optimizer.zero_grad()
+            pbar.set_description(f"QAT Finetuning {iepoch + 1} / {nepochs}, Loss: {quant_loss.detach().item():.5f}, LR: {learningrate:g}")
+
+        # You must remove hooks during onnx export or torch.save
+        for rm in remove_handle:
+            rm.remove()
+
+        if per_epoch_callback:
+            if per_epoch_callback(model, iepoch, learningrate):
+                break
+
+
+def export_onnx(model, input, file, *args, **kwargs):
+    quant_nn.TensorQuantizer.use_fb_fake_quant = True
+
+    model.eval()
+
+    with torch.no_grad():
+        torch.onnx.export(model, input, file, *args, **kwargs)
+
+    quant_nn.TensorQuantizer.use_fb_fake_quant = False

--- a/models/quantize.py
+++ b/models/quantize.py
@@ -55,6 +55,7 @@ import models
 
 ### These classes has not been utilized yet; it's still undergoing testing. #####
 ### BEGIN #####
+""" 
 class QuantSiLU(torch.nn.Module, quant_nn_utils.QuantInputMixin):
     def __init__(self, **kwargs):
         super(QuantSiLU, self).__init__()
@@ -83,7 +84,8 @@ class QuantUpsample(torch.nn.Module):
             self._input_quantizer = quant_nn.TensorQuantizer(QuantDescriptor())
             
         def forward(self, x):
-            return F.interpolate(self._input_quantizer(x), self.size, self.scale_factor, self.mode)
+            return F.interpolate(self._input_quantizer(x), self.size, self.scale_factor, self.mode) 
+"""
            
 ### END #####
         
@@ -257,13 +259,14 @@ def repnbottleneck_quant_forward(self, x):
     return x + self.cv2(self.cv1(x)) if self.add else self.cv2(self.cv1(x))
 
 
+### These def has not been utilized yet; it's still undergoing testing. #####
+### Begin #### 
+""" 
 def concat_quant_forward(self, x):
         if hasattr(self, "concatop"):
             return self.concatop(x, self.d)
         return torch.cat(x, self.d)
 
-### These def has not been utilized yet; it's still undergoing testing. #####
-### Begin #### 
 def upsample_quant_forward(self, x):
         if hasattr(self, "upsampleop"):
             return self.upsampleop(x)
@@ -278,7 +281,7 @@ def repncspelan4_qaunt_forward(self, x):
             y = list(self.cv1(x).split((self.c, self.c), 1))
             y.extend(m(y[-1]) for m in [self.cv2, self.cv3])
             return self.cv4(torch.cat(y, 1))
-        
+"""
 ### End #### 
 
 def apply_custom_rules_to_quantizer(model : torch.nn.Module, export_onnx : Callable):

--- a/models/quantize_rules.py
+++ b/models/quantize_rules.py
@@ -40,13 +40,15 @@ def find_with_output_node(model, name):
         if len(node.output) > 0 and name in node.output:
             return node
 
-# def find_with_no_change_parent_node(model, node):
-#     parent = find_with_output_node(model, node.input[0])
-#     if parent is not None:
-#         print("Parent:", parent.op_type)
-#         if parent.op_type in ["Concat", "MaxPool", "AveragePool", "Slice"]:
-#             return find_with_no_change_parent_node(model, parent)
-#     return parent
+""" 
+def find_with_no_change_parent_node(model, node):
+    parent = find_with_output_node(model, node.input[0])
+    if parent is not None:
+        print("Parent:", parent.op_type)
+        if parent.op_type in ["Concat", "MaxPool", "AveragePool", "Slice"]:
+            return find_with_no_change_parent_node(model, parent)
+    return parent 
+"""
 
 def find_quantizelinear_conv(model, qnode):
     dq   = find_with_input_node(model, qnode.output[0])

--- a/models/quantize_rules.py
+++ b/models/quantize_rules.py
@@ -1,0 +1,98 @@
+################################################################################
+# SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+################################################################################
+
+import onnx
+
+def find_with_input_node(model, name):
+    for node in model.graph.node:
+        if len(node.input) > 0 and name in node.input:
+            return node
+
+def find_all_with_input_node(model, name):
+    all = []
+    for node in model.graph.node:
+        if len(node.input) > 0 and name in node.input:
+            all.append(node)
+    return all
+
+def find_with_output_node(model, name):
+    for node in model.graph.node:
+        if len(node.output) > 0 and name in node.output:
+            return node
+
+# def find_with_no_change_parent_node(model, node):
+#     parent = find_with_output_node(model, node.input[0])
+#     if parent is not None:
+#         print("Parent:", parent.op_type)
+#         if parent.op_type in ["Concat", "MaxPool", "AveragePool", "Slice"]:
+#             return find_with_no_change_parent_node(model, parent)
+#     return parent
+
+def find_quantizelinear_conv(model, qnode):
+    dq   = find_with_input_node(model, qnode.output[0])
+    conv = find_with_input_node(model, dq.output[0])
+    return conv
+
+
+def find_quantize_conv_name(model, weight_qname):
+    dq = find_with_output_node(model, weight_qname)
+    q  = find_with_output_node(model, dq.input[0])
+    return ".".join(q.input[0].split(".")[:-1])
+
+def find_quantizer_pairs(onnx_file):
+
+    model = onnx.load(onnx_file)
+    match_pairs = []
+    for node in model.graph.node:   
+        if node.op_type == "Concat":
+            qnodes = find_all_with_input_node(model, node.output[0])
+            major = None
+            for qnode in qnodes:
+                if qnode.op_type != "QuantizeLinear":
+                    continue
+                conv = find_quantizelinear_conv(model, qnode)
+                if major is None:
+                    major = find_quantize_conv_name(model, conv.input[1])
+                else:
+                    match_pairs.append([major, find_quantize_conv_name(model, conv.input[1])])
+
+                for subnode in model.graph.node:
+                    if len(subnode.input) > 0 and subnode.op_type == "QuantizeLinear" and subnode.input[0] in node.input:
+                        subconv = find_quantizelinear_conv(model, subnode)
+                        match_pairs.append([major, find_quantize_conv_name(model, subconv.input[1])])
+
+
+        elif node.op_type == "MaxPool":
+            qnode = find_with_input_node(model, node.output[0])
+            if not (qnode and qnode.op_type == "QuantizeLinear"):
+                continue
+            major = find_quantizelinear_conv(model, qnode)
+            major = find_quantize_conv_name(model, major.input[1])
+            same_input_nodes = find_all_with_input_node(model, node.input[0])
+
+            for same_input_node in same_input_nodes:
+                if same_input_node.op_type == "QuantizeLinear":
+                    subconv = find_quantizelinear_conv(model, same_input_node)
+                    match_pairs.append([major, find_quantize_conv_name(model, subconv.input[1])])
+                   
+    return match_pairs

--- a/qat.py
+++ b/qat.py
@@ -1,0 +1,529 @@
+import sys
+import os
+
+import yaml
+import argparse
+import json
+from copy import deepcopy
+from pathlib import Path
+import warnings
+
+# PyTorch
+import torch
+import torch.nn as nn
+
+import val as validate 
+from models.yolo import Model
+from models.common import Conv
+from utils.dataloaders import create_dataloader
+from utils.downloads import attempt_download
+
+from models.yolo import Detect, DDetect, DualDetect, DualDDetect, DetectionModel, SegmentationModel
+import models.quantize as quantize
+
+from utils.general import (LOGGER, check_dataset, check_requirements, check_img_size, colorstr, init_seeds,increment_path,file_size)
+from utils.torch_utils import (torch_distributed_zero_first)
+
+
+warnings.filterwarnings("ignore")
+
+FILE = Path(__file__).resolve()
+ROOT = FILE.parents[0]  # YOLO root directory
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))  # add ROOT to PATH
+ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
+
+LOCAL_RANK = int(os.getenv('LOCAL_RANK', -1))  # https://pytorch.org/docs/stable/elastic/run.html
+RANK = int(os.getenv('RANK', -1))
+WORLD_SIZE = int(os.getenv('WORLD_SIZE', 1))
+GIT_INFO = None
+
+class SummaryTool:
+    def __init__(self, file):
+        self.file = file
+        self.data = []
+
+    def append(self, item):
+        self.data.append(item)
+        json.dump(self.data, open(self.file, "w"), indent=4)
+
+
+def load_model(weights, device) -> Model:
+    with torch_distributed_zero_first(LOCAL_RANK):
+        attempt_download(weights)
+    model = torch.load(weights, map_location=device)["model"]
+    for m in model.modules():
+        if type(m) is nn.Upsample:
+            m.recompute_scale_factor = None  # torch 1.11.0 compatibility
+        elif type(m) is Conv:
+            m._non_persistent_buffers_set = set()  # pytorch 1.6.0 compatibility
+    model.float()
+    model.eval()
+    with torch.no_grad():
+        model.fuse()
+    return model
+
+
+
+def create_train_dataloader(train_path, imgsz, batch_size, single_cls, stride, hyp_path):
+    with open(hyp_path) as f:
+        hyp = yaml.load(f, Loader=yaml.SafeLoader)  # load hyps
+    loader = create_dataloader(
+        train_path, 
+        imgsz=imgsz, 
+        batch_size=batch_size, 
+        single_cls=single_cls,
+        augment=True, hyp=hyp, rect=False, cache=False, stride=stride, pad=0.0, image_weights=False)[0]
+    return loader
+
+
+
+def create_val_dataloader(test_path, imgsz, batch_size, single_cls, stride, keep_images=None):
+    loader = create_dataloader(
+        test_path, 
+        imgsz=imgsz, 
+        batch_size=batch_size, 
+        single_cls=single_cls,
+        augment=False, hyp=None, rect=True, cache=False,stride=stride,pad=0.5, image_weights=False)[0]
+
+    def subclass_len(self):
+        if keep_images is not None:
+            return keep_images
+        return len(self.img_files)
+    
+    loader.dataset.__len__ = subclass_len
+    return loader
+
+def evaluate_dataset(model_eval, val_loader, imgsz, data_dict, single_cls, save_dir, is_coco, conf_thres=0.001 , iou_thres=0.7 ):
+    return validate.run(data_dict,
+                        model=model_eval,
+                        imgsz=imgsz,
+                        single_cls=single_cls,
+                        half=True,
+                        task='val',
+                        verbose=True,
+                        conf_thres=conf_thres, 
+                        iou_thres=iou_thres,
+                        save_dir=save_dir,
+                        save_json=is_coco,
+                        dataloader=val_loader,  
+                        )[0][:4]
+
+
+def export_onnx(model, file, im, opset=12, dynamic=False, prefix=colorstr('QAT ONNX:')):
+    check_requirements('onnx')
+    import onnx
+
+    file = Path(file)
+    LOGGER.info(f'\n{prefix} starting export with onnx {onnx.__version__}...')
+
+    f = file.with_suffix('.onnx')
+    output_names = ['output0', 'output1'] if isinstance(model, SegmentationModel) else ['output0']
+    model.eval()
+    for k, m in model.named_modules():
+        # print(m)
+        if isinstance(m, (Detect, DDetect, DualDetect, DualDDetect)):
+            m.inplace = True
+            m.dynamic = dynamic
+            m.export = True
+    dynamic = {'images': {0: 'batch', 2: 'height', 3: 'width'}}  # shape(1,3,640,640)
+    if isinstance(model, SegmentationModel):
+        dynamic['output0'] = {0: 'batch', 1: 'anchors'}  # shape(1,25200,85)
+        dynamic['output1'] = {0: 'batch', 2: 'mask_height', 3: 'mask_width'}  # shape(1,32,160,160)
+    elif isinstance(model, DetectionModel):
+        dynamic['output0'] = {0: 'batch', 1: 'anchors'}  # shape(1,25200,85)
+    
+    quantize.export_onnx(model, im, file, opset_version=13, 
+         input_names=["images"], output_names=output_names, 
+         dynamic_axes=dynamic or None
+     )
+    
+    for k, m in model.named_modules():
+        if isinstance(m, (Detect, DDetect, DualDetect, DualDDetect)):
+            m.inplace = True
+            m.dynamic = False
+            m.export = False
+    
+
+def run_quantize(weights, data, imgsz, batch_size, hyp, device, no_last_layer, save_dir, supervision_stride, iters, no_eval_origin, no_eval_ptq, eval_pycocotools, prefix=colorstr('QAT:')):
+    
+    if not Path(weights).exists():
+        LOGGER.info(f'{prefix} Weight file not found "{weights}"  ❌')
+        exit(1)
+        
+    quantize.initialize()
+    with torch_distributed_zero_first(LOCAL_RANK):
+        data_dict = check_dataset(data)
+
+    w = save_dir / 'weights'  # weights dir
+    w.mkdir(parents=True, exist_ok=True)   # make dir
+
+    is_coco = isinstance(data_dict.get('val'), str) and data_dict['val'].endswith(f'val2017.txt')  # COCO dataset
+    if is_coco and not eval_pycocotools:
+        is_coco=False
+    
+    nc = int(data_dict['nc'])  # number of classes
+    single_cls = False if nc > 1 else True
+    names = data_dict['names']  # class names
+    assert len(names) == nc, '%g names found for nc=%g dataset in %s' % (len(names), nc, data_dict)  # check
+    train_path = data_dict['train']
+    test_path = data_dict['val']
+
+    result_eval_origin=None
+    result_eval_ptq=None
+    result_eval_qat_best=None
+
+    
+
+    device  = torch.device(device)
+    model   = load_model(weights, device)
+
+    if not isinstance(model, DetectionModel):
+            model_name=model.__class__.__name__
+            LOGGER.info(f'{prefix} {model_name} model is not supported. Only DetectionModel is supported.  ❌')
+            exit(1)
+
+    stride = max(int(model.stride.max()), 32)  # grid size (max stride)
+    imgsz = check_img_size(imgsz, s=stride)  # check image size
+
+    # conf onnx export
+    exp_imgsz=[imgsz,imgsz]
+    gs = int(max(model.stride))  # grid size (max stride)
+    exp_imgsz = [check_img_size(x, gs) for x in exp_imgsz]  # verify img_size are gs-multiples
+    im = torch.zeros(batch_size, 3, *exp_imgsz).to(device)  # image size(1,3,320,192) BCHW iDetection
+
+
+    train_dataloader = create_train_dataloader(train_path, imgsz, batch_size, single_cls, stride, hyp)
+    val_dataloader   = create_val_dataloader(test_path, imgsz, batch_size, single_cls, stride)
+    
+    ### This rule is disabled - This allow user disable qat per Layers ###
+    # This rule has been disabled, but it remains in the code to maintain compatibility or future implementation.
+    ignore_layer=-1
+    if ignore_layer > -1:
+        ignore_policy=f"model\.{ignore_layer}\.cv\d+\.\d+\.\d+(\.conv)?"
+    else:
+        ignore_policy=f"model\.9999999999\.cv\d+\.\d+\.\d+(\.conv)?"   
+    ### End ####### 
+        
+    quantize.replace_custom_module_forward(model)
+    quantize.replace_to_quantization_module(model, ignore_policy=ignore_policy)
+    quantize.apply_custom_rules_to_quantizer(model, lambda model, file: export_onnx(model, file, im))
+    quantize.calibrate_model(model, train_dataloader, device)
+
+    summary_file = os.path.join(save_dir, "summary.json")
+    summary = SummaryTool(summary_file)
+
+    if no_eval_origin:
+        LOGGER.info(f'\n{prefix} Evaluating Origin...')
+        model_eval = deepcopy(model).eval()  
+        with quantize.disable_quantization(model_eval):
+            result_eval_origin = evaluate_dataset(model_eval, val_dataloader, imgsz, data_dict, single_cls, save_dir, is_coco )
+            eval_mp, eval_mr, eval_map50, eval_map= tuple(round(x, 4) for x in result_eval_origin)
+            LOGGER.info(f'\n{prefix} Eval Origin  - AP: {eval_map} AP50: {eval_map50} Precision: {eval_mp} Recall: {eval_mr}')
+            summary.append(["Origin", eval_map])
+
+    if no_eval_ptq:
+        
+        LOGGER.info(f'\n{prefix} Evaluating PTQ...')
+        model_eval = deepcopy(model).eval()  
+        
+        if no_last_layer:
+            last_layer_index = len(model_eval.model) - 1
+            last_layer = model_eval.model[last_layer_index]
+            if quantize.have_quantizer(last_layer):
+                LOGGER.info(f'{prefix} Quantization disabled for Last Layer model.{last_layer_index}')
+                quantize.disable_quantization(last_layer).apply()
+        
+        result_eval_ptq = evaluate_dataset(model_eval, val_dataloader, imgsz, data_dict, single_cls, save_dir, is_coco )
+        eval_mp, eval_mr, eval_map50, eval_map= tuple(round(x, 4) for x in result_eval_ptq)
+        summary.append(["PQT", eval_map])
+        LOGGER.info(f'\n{prefix} Eval PQT - AP: {eval_map} AP50: {eval_map50} Precision: {eval_mp} Recall: {eval_mr}')
+        ptq_weights = w /  f'ptq_{os.path.basename(weights)}'
+        torch.save({"model": model_eval},f'{ptq_weights}')
+        LOGGER.info(f'\n{prefix} PTQ, weights saved as {ptq_weights} ({file_size(ptq_weights):.1f} MB)')
+
+    best_map = 0
+
+    def per_epoch(model, epoch, lr):
+        nonlocal best_map , result_eval_qat_best
+
+        epoch +=1
+        model_eval = deepcopy(model).eval()  
+        with torch.no_grad():  
+            eval_result = evaluate_dataset(model_eval, val_dataloader, imgsz, data_dict, single_cls, save_dir, is_coco )
+            eval_mp, eval_mr, eval_map50, eval_map= tuple(round(x, 4) for x in eval_result)
+            summary.append([f"QAT{epoch}", eval_map])
+        #print_map_scores(summary_file)
+        qat_weights = w /  f'qat_{epoch}_{os.path.basename(weights)}'
+        torch.save({"model": model_eval},f'{qat_weights}')
+        LOGGER.info(f'\n{prefix} Epoch-{epoch}, weights saved as {qat_weights} ({file_size(qat_weights):.1f} MB)')
+        if eval_map > best_map:
+            best_map = eval_map
+            result_eval_qat_best=eval_result
+            qat_weights = w /  f'qat_best_{os.path.basename(weights)}'
+            torch.save({"model": model_eval}, f'{qat_weights}')
+            LOGGER.info(f'{prefix} QAT Best, weights saved as {qat_weights} ({file_size(qat_weights):.1f} MB)')
+
+        eval_results = [result_eval_origin, result_eval_ptq, result_eval_qat_best]
+         
+        LOGGER.info(f'\n\nEval Model | {"AP":<8} | {"AP50":<8} | {"Precision":<10} | {"Recall":<8}')
+        LOGGER.info('-' * 55)  
+        for idx, eval_r in enumerate(eval_results):
+            if eval_r is not None:
+                eval_mp, eval_mr, eval_map50, eval_map = tuple(round(x, 4) for x in eval_r)
+                if idx == 0:
+                    LOGGER.info(f'Origin     | {eval_map:<8} | {eval_map50:<8} | {eval_mp:<10} | {eval_mr:<8}')
+                if idx == 1:
+                    LOGGER.info(f'PQT        | {eval_map:<8} | {eval_map50:<8} | {eval_mp:<10} | {eval_mr:<8}')
+                if idx == 2:
+                    LOGGER.info(f'QAT (Best) | {eval_map:<8} | {eval_map50:<8} | {eval_mp:<10} | {eval_mr:<8}\n')
+            
+        eval_mp, eval_mr, eval_map50, eval_map= tuple(round(x, 4) for x in eval_result)
+        LOGGER.info(f'\n{prefix} Eval - Epoch {epoch} | AP: {eval_map}  | AP50: {eval_map50} | Precision: {eval_mp} | Recall: {eval_mr}\n')
+
+    def preprocess(datas):
+        return datas[0].to(device).float() / 255.0
+
+    def supervision_policy():
+        supervision_list = []
+        for item in model.model:
+            supervision_list.append(id(item))
+
+        keep_idx = list(range(0, len(model.model) - 1, supervision_stride))
+        keep_idx.append(len(model.model) - 2)
+        def impl(name, module):
+            if id(module) not in supervision_list: return False
+            idx = supervision_list.index(id(module))
+            if idx in keep_idx:
+                print(f"Supervision: {name} will compute loss with origin model during QAT training")
+            else:
+                print(f"Supervision: {name} no compute loss during QAT training, that is unsupervised only and doesn't mean don't learn")
+            return idx in keep_idx
+        return impl
+
+    quantize.finetune(
+        model, train_dataloader, no_last_layer, per_epoch, early_exit_batchs_per_epoch=iters, 
+        preprocess=preprocess, supervision_policy=supervision_policy())
+
+def run_sensitive_analysis(weights, device, data, imgsz, batch_size, hyp, save_dir, num_image, prefix=colorstr('QAT ANALYSIS:')):
+    quantize.initialize()
+    if not Path(weights).exists():
+        LOGGER.info(f'{prefix} Weight file not found "{weights}"  ❌')
+        exit(1)
+        
+    save_dir = Path(save_dir)
+    # Create the directory if it doesn't exist
+    save_dir.mkdir(parents=True, exist_ok=opt.exist_ok)
+
+    with torch_distributed_zero_first(LOCAL_RANK):
+        data_dict = check_dataset(data)
+
+    is_coco=False
+    
+    nc = int(data_dict['nc'])  # number of classes
+    single_cls = False if nc > 1 else True
+    names = data_dict['names']  # class names
+    assert len(names) == nc, '%g names found for nc=%g dataset in %s' % (len(names), nc, data_dict)  # check
+    train_path = data_dict['train']
+    test_path = data_dict['val']
+
+    device  = torch.device(device)
+    model   = load_model(weights, device)
+
+    if not isinstance(model, DetectionModel):
+        model_name=model.__class__.__name__
+        LOGGER.info(f'{prefix} {model_name} model is not supported. Only DetectionModel is supported.  ❌')
+        exit(1)
+
+    is_model_qat=False
+    for i in range(0, len(model.model)):
+        layer = model.model[i]
+        if quantize.have_quantizer(layer):
+            is_model_qat=True
+            break
+
+    if is_model_qat:
+        LOGGER.info(f'{prefix} This model already quantized. Only not quantized models is allowed. ❌')
+        exit(1)
+
+    stride = max(int(model.stride.max()), 32)  # grid size (max stride)
+    imgsz = check_img_size(imgsz, s=stride)  # check image size
+
+
+    train_dataloader = create_train_dataloader(train_path, imgsz, batch_size, single_cls, stride, hyp)
+    val_dataloader   = create_val_dataloader(test_path, imgsz, batch_size, single_cls, stride)
+
+    quantize.replace_to_quantization_module(model)
+    quantize.calibrate_model(model, train_dataloader, device)
+
+    summary_file=os.path.join(save_dir , "summary-sensitive-analysis.json")
+    summary = SummaryTool(summary_file)
+
+    model_eval = deepcopy(model).eval() 
+    LOGGER.info(f'\n{prefix} Evaluating PTQ...')
+
+    eval_result = evaluate_dataset(model_eval, val_dataloader, imgsz, data_dict, single_cls, save_dir, is_coco )
+    eval_mp, eval_mr, eval_map50, eval_map= tuple(round(x, 4) for x in eval_result)
+
+    LOGGER.info(f'\n{prefix} Eval PQT - QAT enabled on All Layers - AP: {eval_map} AP50: {eval_map50} Precision: {eval_mp} Recall: {eval_mr}')
+    summary.append([eval_map, "PQT"])
+    LOGGER.info(f'{prefix} Sensitive analysis by each layer. Layers Detected: {len(model.model)}')
+
+    for i in range(0, len(model.model)):
+        layer = model.model[i]
+        if quantize.have_quantizer(layer):
+            LOGGER.info(f'{prefix} QAT disabled on Layer model.{i}')
+            quantize.disable_quantization(layer).apply()
+            model_eval = deepcopy(model).eval()   
+            eval_result = evaluate_dataset(model_eval, val_dataloader, imgsz, data_dict, single_cls, save_dir, is_coco )
+            eval_mp, eval_mr, eval_map50, eval_map= tuple(round(x, 4) for x in eval_result)
+            LOGGER.info(f'\n{prefix} Eval PQT - QAT disabled on Layer model.{i} - AP: {eval_map} AP50: {eval_map50} Precision: {eval_mp} Recall: {eval_mr}\n')
+            summary.append([eval_map, f"model.{i}"]) 
+            quantize.enable_quantization(layer).apply()
+        else:
+            LOGGER.info(f'{prefix} Ignored Layer model.{i} because it is {type(layer)}')
+    
+    summary = sorted(summary.data, key=lambda x:x[0], reverse=True)
+    print("Sensitive summary:")
+    for n, (ap, name) in enumerate(summary[:10]):
+        print(f"Top{n}: Using fp16 {name}, ap = {ap:.5f}")
+
+
+def run_eval(weights, device, data, imgsz, batch_size, save_dir, conf_thres, iou_thres, eval_pycocotools, prefix=colorstr('QAT TEST:')):
+    
+    if not Path(weights).exists():
+        LOGGER.info(f'{prefix} Weight file not found "{weights}"  ❌')
+        exit(1)
+    
+    quantize.initialize()
+
+    save_dir = Path(save_dir)
+    # Create the directory if it doesn't exist
+    save_dir.mkdir(parents=True, exist_ok=opt.exist_ok)
+
+    with torch_distributed_zero_first(LOCAL_RANK):
+        data_dict = check_dataset(data)
+
+   
+    device  = torch.device(device)
+    model   = load_model(weights, device)
+
+    if not isinstance(model, DetectionModel):
+        model_name=model.__class__.__name__
+        LOGGER.info(f'{prefix} {model_name} model is not supported. Only DetectionModel is supported.  ❌')
+        exit(1)
+
+    is_model_qat=False
+    for i in range(0, len(model.model)):
+        layer = model.model[i]
+        if quantize.have_quantizer(layer):
+            is_model_qat=True
+            break
+    
+    if not is_model_qat:
+        LOGGER.info(f'{prefix} This model was not Quantized. ❌')
+        exit(1)
+    
+    is_coco = isinstance(data_dict.get('val'), str) and data_dict['val'].endswith(f'val2017.txt')  # COCO dataset
+    if is_coco and not eval_pycocotools:
+        is_coco=False
+
+    stride = max(int(model.stride.max()), 32)  # grid size (max stride)
+    imgsz = check_img_size(imgsz, s=stride)  # check image size
+
+    nc = int(data_dict['nc'])  # number of classes
+    single_cls = False if nc > 1 else True
+    names = data_dict['names']  # class names
+    assert len(names) == nc, '%g names found for nc=%g dataset in %s' % (len(names), nc, data_dict)  # check
+
+    test_path = data_dict['val']
+    val_dataloader   = create_val_dataloader(test_path, imgsz, batch_size, single_cls, stride)
+
+    
+    LOGGER.info(f'\n{prefix} Evaluating ...')
+    model_eval = deepcopy(model).eval()  
+ 
+    result_eval = evaluate_dataset(model_eval, val_dataloader, imgsz, data_dict, single_cls, save_dir, is_coco, conf_thres=conf_thres, iou_thres=iou_thres  )
+    eval_mp, eval_mr, eval_map50, eval_map= tuple(round(x, 4) for x in result_eval)
+    LOGGER.info(f'\n{prefix} Eval Result - AP: {eval_map} AP50: {eval_map50} Precision: {eval_mp} Recall: {eval_mr}')
+    LOGGER.info(f'\n{prefix} Eval Result, saved on {save_dir}')
+   
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(prog='qat.py')
+    subps  = parser.add_subparsers(dest="cmd")
+    qat = subps.add_parser("quantize", help="PTQ/QAT finetune ...")
+
+    qat.add_argument('--weights', type=str, default=ROOT / 'runs/models_original/yolov9-c.pt', help='weights path')
+    qat.add_argument('--data', type=str, default=ROOT / 'data/coco.yaml', help='dataset.yaml path')
+    qat.add_argument('--hyp', type=str, default=ROOT / 'data/hyps/hyp.scratch-high.yaml', help='hyperparameters path')
+    qat.add_argument("--device", type=str, default="cuda:0", help="device")
+    qat.add_argument('--batch-size', type=int, default=10, help='total batch size')
+    qat.add_argument('--imgsz', '--img', '--img-size', type=int, default=640, help='train, val image size (pixels)')
+    qat.add_argument('--project', default=ROOT / 'runs/qat', help='save to project/name')
+    qat.add_argument('--name', default='exp', help='save to project/name')
+    qat.add_argument('--exist-ok', action='store_true', help='existing project/name ok, do not increment')
+    qat.add_argument("--iters", type=int, default=200, help="iters per epoch")
+    qat.add_argument('--seed', type=int, default=57, help='Global training seed')
+    qat.add_argument("--no-last-layer", action="store_true", help="Disable QAT on Last Layer to improve mAP but also increase Latency")
+    qat.add_argument("--supervision-stride", type=int, default=1, help="supervision stride")
+    qat.add_argument("--no-eval-origin", action="store_false", help="Disable eval for origin model")
+    qat.add_argument("--no-eval-ptq", action="store_false", help="Disable eval for ptq model")
+    qat.add_argument("--eval-pycocotools", action="store_true", help="Evalution using Pycocotools. Valid only for COCO Dataset")
+
+    sensitive = subps.add_parser("sensitive", help="Sensitive layer analysis")
+    sensitive.add_argument('--weights', type=str, default=ROOT / 'runs/models_original/yolov9-c.pt', help='Weights path (.pt)')
+    sensitive.add_argument("--device", type=str, default="cuda:0", help="device")
+    sensitive.add_argument('--data', type=str, default='data/coco.yaml', help='data.yaml path')
+    sensitive.add_argument('--batch-size', type=int, default=10, help='total batch size')
+    sensitive.add_argument('--imgsz', '--img', '--img-size', type=int, default=640, help='train, val image size (pixels)')
+    sensitive.add_argument('--hyp', type=str, default='data/hyps/hyp.scratch-high.yaml', help='hyperparameters path') 
+    sensitive.add_argument('--project', default=ROOT / 'runs/qat_sentive', help='save to project/name')
+    sensitive.add_argument('--name', default='exp', help='save to project/name')
+    sensitive.add_argument('--exist-ok', action='store_true', help='existing project/name ok, do not increment')
+    sensitive.add_argument("--num-image", type=int, default=None, help="number of image to evaluate")
+
+    testcmd = subps.add_parser("eval", help="Do evaluate")
+    testcmd.add_argument('--weights', type=str, default=ROOT / 'runs/models_original/yolov9-c.pt', help='Weights path (.pt)')
+    testcmd.add_argument('--data', type=str, default='data/coco.yaml', help='data.yaml path')
+    testcmd.add_argument('--batch-size', type=int, default=10, help='total batch size')
+    testcmd.add_argument('--imgsz', '--img', '--img-size', type=int, default=640, help='val image size (pixels)')
+    testcmd.add_argument("--device", type=str, default="cuda:0", help="device")
+    testcmd.add_argument("--conf-thres", type=float, default=0.001, help="confidence threshold")
+    testcmd.add_argument("--iou-thres", type=float, default=0.7, help="nms threshold")
+    testcmd.add_argument('--project', default=ROOT / 'runs/qat_eval', help='save to project/name')
+    testcmd.add_argument('--name', default='exp', help='save to project/name')
+    testcmd.add_argument('--exist-ok', action='store_true', help='existing project/name ok, do not increment')
+    testcmd.add_argument("--use-pycocotools", action="store_true", help="Generate COCO annotation json format for the custom dataset")
+
+
+    opt = parser.parse_args()
+    if opt.cmd == "quantize":
+        print(opt)
+        opt.save_dir = str(increment_path(Path(opt.project) / opt.name, exist_ok=opt.exist_ok))
+        init_seeds(opt.seed + 1 + RANK, deterministic=False)
+
+        run_quantize(
+            opt.weights, opt.data, opt.imgsz, opt.batch_size, 
+            opt.hyp, opt.device, opt.no_last_layer, Path(opt.save_dir), 
+             opt.supervision_stride, opt.iters,
+            opt.no_eval_origin, opt.no_eval_ptq, opt.eval_pycocotools
+        )
+
+    elif opt.cmd == "sensitive":
+        opt.save_dir = str(increment_path(Path(opt.project) / opt.name, exist_ok=opt.exist_ok))
+        print(opt)
+        run_sensitive_analysis(opt.weights, opt.device, opt.data, 
+                               opt.imgsz, opt.batch_size, opt.hyp, 
+                               opt.save_dir, opt.num_image 
+                               )
+    elif opt.cmd == "eval":
+        opt.save_dir = str(increment_path(Path(opt.project) / opt.name, exist_ok=opt.exist_ok))
+        print(opt)
+        run_eval(opt.weights, opt.device, opt.data, 
+                 opt.imgsz, opt.batch_size, opt.save_dir, 
+                 opt.conf_thres, opt.iou_thres, opt.use_pycocotools
+                 )
+    else:
+        parser.print_help()


### PR DESCRIPTION
Initial version of YOLOv9-QAT using the Q/DQ method, tailored specifically for YOLOv9 models intended for execution solely on TensorRT. <br>
This implementation currently supports only the Inference Models (Converted and Gelan models).
 


## Challenges
Quantizing all layers in some cases can decreases accuracy and increases latency, primarily due to the complexity of the last layer. To mitigate this, utilize the `qat.py quantize --no-last-layer` flag to exclude the last layer from quantization. 

This version we have unoptimized scaling of Quantize/Dequantize (Q/DQ) could lead to generating unnecessary data formats. Implementing restrictions on the scale of Q/DQ on [models/quantize.py](https://github.com/levipereira/yolov9/blob/yolov9-qat/models/quantize.py)   to match the data format is essential to decrease latency perfomance.
The contributions from the community, as their knowledge is essential for the correct implementation of this functionality.


## Files Added / Modified 
[qat.py](https://github.com/levipereira/yolov9/blob/yolov9-qat/qat.py) - Main 
```
usage: qat.py [-h] {quantize,sensitive,eval} ...
positional arguments:
  {quantize,sensitive,eval}
    quantize            PTQ/QAT finetune ...
    sensitive           Sensitive layer analysis
    eval                Do evaluate
```

[models/quantize.py](https://github.com/levipereira/yolov9/blob/yolov9-qat/models/quantize.py) - Quantize Module
[models/quantize_rules.py](https://github.com/levipereira/yolov9/blob/yolov9-qat/models/quantize_rules.py) - Quantize Rules
[export.py](https://github.com/levipereira/yolov9/blob/yolov9-qat/export.py) - Changed to Automatically detect QAT Models and Export when using flag `--include onnx  / onnx_end2end`
 
  
 # Accuracy Report
 
 ```
 QAT YOLOV9-C - ALL LAYERS 
Eval Model | AP       | AP50     | Precision  | Recall
-------------------------------------------------------
Origin     | 0.5297   | 0.699    | 0.7432     | 0.634
PQT        | 0.5295   | 0.6978   | 0.7455     | 0.6306
QAT- Best  | 0.5291   | 0.6978   | 0.7449     | 0.632

QAT - YOLOV9-C  - NO QAT LAST LAYER 
Eval Model | AP       | AP50     | Precision  | Recall  
-------------------------------------------------------
Origin     | 0.5297   | 0.699    | 0.7432     | 0.634   
PQT        | 0.529    | 0.698    | 0.7459     | 0.6297  
QAT- Best  | 0.5299   | 0.6984   | 0.7469     | 0.6305  

QAT - YOLOV9-E ALL-LAYERS
Eval Model | AP       | AP50     | Precision  | Recall
-------------------------------------------------------
Origin     | 0.5576   | 0.7246   | 0.7547     | 0.6649
PQT        | 0.5565   | 0.7241   | 0.7499     | 0.6649
QAT- Best  | 0.5566   | 0.7232   | 0.7538     | 0.6637


QAT - YOLOV9-E  - NO QAT  LAST LAYER
Eval Model | AP       | AP50     | Precision  | Recall  
-------------------------------------------------------
Origin     | 0.5576   | 0.7246   | 0.7547     | 0.6649  
PQT        | 0.5569   | 0.7242   | 0.7497     | 0.6646  
QAT- Best  | 0.5569   | 0.7239   | 0.7486     | 0.6657  



 ```
 
Result using TensorRT engine Models on Triton-Server
Tool: https://github.com/levipereira/triton-client-yolo
 ```
 ========================= EVALUATION SUMMARY - YOLOV9-C ========================
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.528
 Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.701
 Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.577
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.361
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.582
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.689
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.392
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.652
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.701
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.538
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.759
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.848
================================================================================
mAP@0.5:0.95: 0.528
mAP@0.5:      0.701
mAP@0.75:     0.577
================================================================================


========================= EVALUATION SUMMARY - YOLOV9-C-QAT ========================
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.528
 Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.699
 Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.576
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.359
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.581
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.692
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.392
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.651
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.699
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.534
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.758
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.845
================================================================================
mAP@0.5:0.95: 0.528
mAP@0.5:      0.699
mAP@0.75:     0.576
================================================================================
```

# Latency Report
- Device Properties:
  * Selected Device: NVIDIA GeForce RTX 4090
    - Compute Capability: 8.9
    - SMs: 128.0
    - Compute Clock Rate: 2.58
    - Device Global Memory: 24207 MiB
    - Shared Memory per SM: 100 KiB
    - Memory Bus Width: 384.0
    - Memory Clock Rate: 10.501

Table Info:
*  "Average time": refers to the sum of the layer latencies, when profiling layers separately.
* "Throughput": is measured in inferences per second (IPS).
## Origin
| Model    | Precision Type | Batch Size | Layers | Weights (MB) | Activations (MB) | Throughput (IPS) | Total Throughput (IPS) | Average time (ms) |
|----------|----------------|------------|--------|---------------|-------------------|------------------|------------------------|-------------------|
| yolov9-c | FP16           | 1          | 271    | 48.2          | 611.7             | 792              | 792                    | 2.1               |
|   |           | 8          | 273    | 48.2          | 4809.1            | 151           | 1209                | 7.3             |
|          |                |            |        |               |                   |                  |                        |                   |
| yolov9-e | FP16           | 8          | 477    | 109.3         | 13461.3           | 57           | 457                 | 18.8             |
|   |            | 1          | 487    | 109.3         | 1706.5            | 353              | 353                    | 4.3               |




##  Last Layer not Quantized 

| Model        | Precision Type | Batch Size | Layers | Weights (MB) | Activations (MB) | Throughput (IPS) | Total Throughput (IPS) | Average time (ms) |
|--------------|----------------|------------|--------|---------------|-------------------|------------------|------------------------|-------------------|
| yolov9-c-qat | FP16 INT8      | 1          | 288    | 29.4          | 534.7             | 951              | 951                    | 1.9               |
|              |                | 8          | 287    | 29.4          | 4190.2            | 181              | 1447                   | 6.4               |
|              |                |            |        |               |                   |                  |                        |                   |
| yolov9-e-qat | FP16 INT8      | 1          | 526    | 63.1          | 1757.0            | 405              | 405                    | 4.1               |
|              |                | 8          | 526    | 63.1          | 13407.7           | 60               | 482                    | 18.2              |



 ##  All Layers Quantized 
| Model        | Precision Type | Batch Size | Layers | Weights (MB) | Activations (MB) | Throughput (IPS) | Total Throughput (IPS) | Average time (ms) |
|--------------|----------------|------------|--------|---------------|-------------------|------------------|------------------------|-------------------|
| yolov9-c-qat | FP16 INT8      | 1          | 295    | 24.2          | 540.1             | 957              | 957              | 1.9               |
|   |       | 8          | 293    | 24.2          | 4216.7            | 193              | 1547                   | 6.1               |
|              |                |            |        |               |                   |                  |                        |                   |
| yolov9-e-qat | FP16 INT8      | 1          | 532    | 57.8          | 1779.5            | 396              | 396                    | 4.1               |
|   |       | 8          | 532    | 57.8          | 13431.8           | 62               | 493                    | 17.8              |
