### PR TITLE
Ensure CPU cores are utilized during training

### DIFF
--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -93,6 +93,7 @@ def seed_worker(worker_id):
     worker_seed = torch.initial_seed() % 2 ** 32
     np.random.seed(worker_seed)
     random.seed(worker_seed)
+    os.sched_setaffinity(0, range(os.cpu_count()))
 
 
 def create_dataloader(path,


### PR DESCRIPTION
I noticed while training that only 2 of my 8 cores were being utilized, even though I had configured for 8 workers.
After some digging I found this pytorch thread describing the same issue: https://github.com/pytorch/pytorch/issues/101850#issuecomment-1732412003

Adding this to the worker_init_fn fixed the issue and sped up training significantly🚀