### PR TITLE
Add Roboflow blog link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Implementation of paper - [YOLOv9: Learning What You Want to Learn Using Program
 [![Hugging Face Spaces](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Spaces-blue)](https://huggingface.co/merve/yolov9)
 [![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/roboflow-ai/notebooks/blob/main/notebooks/train-yolov9-object-detection-on-custom-dataset.ipynb)
 [![OpenCV](https://img.shields.io/badge/OpenCV-BlogPost-black?logo=opencv&labelColor=blue&color=black)](https://learnopencv.com/yolov9-advancing-the-yolo-legacy/)
+[![Roboflow Blog](https://raw.githubusercontent.com/roboflow-ai/notebooks/main/assets/badges/roboflow-blogpost.svg)](https://blog.roboflow.com/train-yolov9-model)
 
 <div align="center">
     <a href="./">


### PR DESCRIPTION
This PR adds a link to [Roboflow's analysis of YOLOv9](https://blog.roboflow.com/train-yolov9-model/) to the repository README.