### PR TITLE
Add layer_map argument & fix transferred weights output

### DIFF
--- a/train_dual.py
+++ b/train_dual.py
@@ -114,7 +114,7 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
         csd = map_dicts(layer_map, csd) if len(layer_map) > 0 else csd  # layer remapping
         csd = intersect_dicts(csd, model.state_dict(), exclude=exclude)  # intersect
         model.load_state_dict(csd, strict=False)  # load
-        LOGGER.info(f'Transferred {len(csd)}/{len(model.state_dict())} items from {weights}')  # report
+        LOGGER.info(f'Transferred {len(csd)}/{len(ckpt["model"].float().state_dict())} items from {weights}. {len(model.state_dict()) - len(csd)} are being newly initialized.')  # report
     else:
         model = Model(cfg, ch=3, nc=nc, anchors=hyp.get('anchors')).to(device)  # create
     amp = check_amp(model)  # check AMP

--- a/utils/general.py
+++ b/utils/general.py
@@ -245,6 +245,21 @@ def init_seeds(seed=0, deterministic=False):
         os.environ['PYTHONHASHSEED'] = str(seed)
 
 
+def map_dicts(map_strs, d):
+    # Split map_strs into list of tuples
+    map_str_list = [map_str.split(',') for map_str in map_strs]
+    
+    for find_str, replace_str in map_str_list:
+        # Create a new dictionary with updated keys
+        mapped_dict = {
+            key.replace(f"model.{find_str}", f"model.{replace_str}"): value 
+            for key, value in d.items()
+        }
+        # Update d to the newly mapped dictionary
+        d = mapped_dict
+    
+    return d
+
 def intersect_dicts(da, db, exclude=()):
     # Dictionary intersection of matching keys and shapes, omitting 'exclude' keys, using da values
     return {k: v for k, v in da.items() if k in db and all(x not in k for x in exclude) and v.shape == db[k].shape}


### PR DESCRIPTION
This argument is useful if you make additions to a .yaml model config file and want to change how pre-trained weights are loaded into it accordingly.

For example, if you add a new layer before the final detection layer of yolov9-c.yaml, you may want to remap the detection layer of an already-trained model from 38 to 39 by passing in --layer_map 38,39. This will allow all the weights of the pre-trained model to be utilized and leave the new layer 38 a fresh slate.

Additionally, correctly output the fraction of weights loaded from the pre-trained weights file. Also show the number of weights in the current model that will be freshly initialized.