### PR TITLE
Fixed error of getsize

### DIFF
--- a/utils/plots.py
+++ b/utils/plots.py
@@ -83,7 +83,7 @@ class Annotator:
         if self.pil or not is_ascii(label):
             self.draw.rectangle(box, width=self.lw, outline=color)  # box
             if label:
-                w, h = self.font.getsize(label)  # text width, height
+                w, h = self.font.getbbox(label)[2:4]  # bounding box, get width and height
                 outside = box[1] - h >= 0  # label fits outside box
                 self.draw.rectangle(
                     (box[0], box[1] - h if outside else box[1], box[0] + w + 1,
@@ -162,7 +162,7 @@ class Annotator:
     def text(self, xy, text, txt_color=(255, 255, 255), anchor='top'):
         # Add text to image (PIL-only)
         if anchor == 'bottom':  # start y from font bottom
-            w, h = self.font.getsize(text)  # text width, height
+            w, h = self.font.getbbox(text)[2:4]  # get bounding box, extract width and height
             xy[1] += 1 - h
         self.draw.text(xy, text, fill=txt_color, font=self.font)
 


### PR DESCRIPTION
Execution of the code gives the following error
  File "/content/yolov9/utils/plots.py", line 300, in plot_images
    annotator.box_label(box, label, color=color)
  File "/content/yolov9/utils/plots.py", line 86, in box_label
    w, h = self.font.getsize(label)  # text width, height
AttributeError: 'FreeTypeFont' object has no attribute 'getsize'

Changes made
```
#Old code:
w, h = self.font.getsize(label)  # text width, height

#New code:
w, h = self.font.getbbox(label)[2:4]  # bounding box, get width and height

```
AND

```
# Old code
w, h = self.font.getsize(text)  # text width, height

#New code:
w, h = self.font.getbbox(text)[2:4]  # get bounding box, extract width and height

```