### PR TITLE
Update val.py : fix: replace otp.min_items with min_items

### DIFF
--- a/val.py
+++ b/val.py
@@ -160,7 +160,7 @@ def run(
                                        pad=pad,
                                        rect=rect,
                                        workers=workers,
-                                       min_items=opt.min_items,
+                                       min_items=min_items,
                                        prefix=colorstr(f'{task}: '))[0]
 
     seen = 0


### PR DESCRIPTION
This PR fixes a typo in the create_dataloader call inside val.py.
Previously, the argument was passed as otp.min_items, which caused an error since otp is not defined.
It has been corrected to use the proper variable min_items.

Changes:

Replaced otp.min_items with min_items in val.py (line 163).

Why:
Without this fix, running validation fails due to an undefined reference. This update ensures the dataloader receives the correct argument.